### PR TITLE
fix: Resolve FutureWarning in filter_outliers

### DIFF
--- a/utils/preprocessing.py
+++ b/utils/preprocessing.py
@@ -34,5 +34,6 @@ def filter_outliers(
         return group[(group[value_col] >= lower) & (group[value_col] <= upper)]
 
     # Apply filtering per group
-    filtered_df = df.groupby(group_col, group_keys=False).apply(_filter_group)
+    filtered_subset = df.groupby(group_col, group_keys=False).apply(_filter_group, include_groups=False)
+    filtered_df = df.loc[filtered_subset.index]
     return filtered_df.reset_index(drop=True)


### PR DESCRIPTION
This commit resolves a `FutureWarning` from pandas in the `filter_outliers` function. The warning was caused by the `DataFrameGroupBy.apply` method operating on the grouping columns.

The fix involves two changes:
1.  Using `include_groups=False` in the `apply` call to prevent the grouping column from being passed to the applied function.
2.  Adjusting the logic to reconstruct the dataframe with the grouping column after the filtering operation, ensuring that the function's output remains the same.

This change makes the code more robust and future-proof without altering its behavior.