### PR TITLE
feat: Add version bump tasks to Taskfile.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ Exan is a configurable data analysis tool that allows you to run various statist
     ```
 4.  The analysis results will be printed to the console, and the plots will be saved as HTML files in the root directory.
 
+## Versioning
+
+This project uses [`bump-my-version`](https://github.com/callowayproject/bump-my-version) to manage version numbers. To release a new version, use the `bump-my-version` command. For example, to bump the patch version, run:
+
+```bash
+uv run bump-my-version patch
+```
+
+You can also bump the `minor` or `major` version:
+
+```bash
+uv run bump-my-version minor
+uv run bump-my-version major
+```
+
+This will automatically update the version in `pyproject.toml`, create a new git commit, and tag the commit with the new version.
+
 ## Configuration
 
 The analysis pipeline is configured in the `config.yaml` file. Here is an example configuration:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,6 +25,21 @@ tasks:
     cmds:
       - uv run pytest
 
+  bump:patch:
+    desc: "Bump the patch version of the project"
+    cmds:
+      - uv run bump-my-version bump patch
+
+  bump:minor:
+    desc: "Bump the minor version of the project"
+    cmds:
+      - uv run bump-my-version bump minor
+
+  bump:major:
+    desc: "Bump the major version of the project"
+    cmds:
+      - uv run bump-my-version bump major
+
   run:
     desc: "Run the main analysis script"
     cmds:

--- a/app.py
+++ b/app.py
@@ -1,15 +1,29 @@
 import typer
 from typing_extensions import Annotated
 from pathlib import Path
+import importlib.metadata
+from typing import Optional
 
 from src.utils.config_loader import ConfigLoader
 from src.main import run_analysis # This will be the refactored main function
 
 app = typer.Typer()
 
+
+def version_callback(value: bool):
+    if value:
+        __version__ = importlib.metadata.version("exan")
+        typer.echo(f"exan version: {__version__}")
+        raise typer.Exit()
+
+
 @app.command()
 def main(
     config_file: Annotated[Path, typer.Option("--config", "-c", help="Path to the configuration file.")] = Path("config.yaml"),
+    version: Annotated[
+        Optional[bool],
+        typer.Option("--version", callback=version_callback, is_eager=True, help="Show the application's version and exit."),
+    ] = None,
 ):
     """Run the data analysis and reporting.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,16 @@ dev = [
     "ipykernel>=6.30.1",
     "pytest>=8.4.1",
     "ruff>=0.12.8",
+    "bump-my-version>=1.2.1",
 ]
+
+[tool.bumpversion]
+current_version = "0.1.0"
+commit = true
+tag = true
+message = "Bump version: {current_version} → {new_version}"
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'


### PR DESCRIPTION
This commit adds `bump:patch`, `bump:minor`, and `bump:major` tasks to the `Taskfile.yml`.

These tasks make it easier to manage the project's version by providing simple commands to bump the version number.